### PR TITLE
George/add cql host stats

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -550,7 +550,7 @@ Connection.prototype.execute = function(query, args, callback) {
 
   start = new Date().getTime();
   queryId = this._getQueryId();
-  self.emit('stat', 'cql-host.[' + self.connectionInfo.host + '].[' + self.connectionInfo.port + ']');
+  self.emit('stat', 'cql-host.' + self.connectionInfo.host.split('.').join('-') + '.' + self.connectionInfo.port);
   self.emit('log', 'cql', cqlString, {
     'query': query,
     'parameterized_query': cqlString,

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -550,7 +550,7 @@ Connection.prototype.execute = function(query, args, callback) {
 
   start = new Date().getTime();
   queryId = this._getQueryId();
-  self.emit('stat', 'cql-host ' + self.connectionInfo.host);
+  self.emit('stat', 'cql-host.[' + self.connectionInfo.host + '].[' + self.connectionInfo.port + ']');
   self.emit('log', 'cql', cqlString, {
     'query': query,
     'parameterized_query': cqlString,

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -550,7 +550,7 @@ Connection.prototype.execute = function(query, args, callback) {
 
   start = new Date().getTime();
   queryId = this._getQueryId();
-  self.emit('stat','cql-host', self.connectionInfo.host);
+  self.emit('stat','cql-host ' + self.connectionInfo.host);
   self.emit('log', 'cql', cqlString, {
     'query': query,
     'parameterized_query': cqlString,

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -550,6 +550,7 @@ Connection.prototype.execute = function(query, args, callback) {
 
   start = new Date().getTime();
   queryId = this._getQueryId();
+  self.emit('stat','cql-host', self.connectionInfo.host);
   self.emit('log', 'cql', cqlString, {
     'query': query,
     'parameterized_query': cqlString,
@@ -850,6 +851,7 @@ var PooledConnection = module.exports.PooledConnection = function(config) {
     });
 
     connection.on('log', this._emitLogMessage.bind(this));
+    connection.on('stat', this._emitStat.bind(this));
     this.connections.push(connection);
   }
 
@@ -860,6 +862,10 @@ util.inherits(PooledConnection, EventEmitter);
 
 PooledConnection.prototype._emitLogMessage = function(level, message, obj) {
   this.emit('log', level, message, obj);
+};
+
+PooledConnection.prototype._emitStat = function(metric, value) {
+  this.emit('stat', metric, value);
 };
 
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -550,7 +550,7 @@ Connection.prototype.execute = function(query, args, callback) {
 
   start = new Date().getTime();
   queryId = this._getQueryId();
-  self.emit('stat','cql-host ' + self.connectionInfo.host);
+  self.emit('stat', 'cql-host ' + self.connectionInfo.host);
   self.emit('log', 'cql', cqlString, {
     'query': query,
     'parameterized_query': cqlString,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": ">= 0.1.12",
     "lodash": ">= 4.2.1",
     "node-uuid": ">= 1.3.3",
-    "thrift": ">= 0.9.1"
+    "thrift": "git+ssh://git@github.com:racker/racker-thrift.git#master"
   },
   "devDependencies": {
     "jshint": "0.9.1",

--- a/test/conf/cassandra-env.sh
+++ b/test/conf/cassandra-env.sh
@@ -150,7 +150,7 @@ if [ "`uname`" = "Linux" ] ; then
     # thread-per-client.  (Best practice is for client connections to
     # be pooled anyway.) Only do so on Linux where it is known to be
     # supported.
-    JVM_OPTS="$JVM_OPTS -Xss128k"
+    JVM_OPTS="$JVM_OPTS -Xss228k"
 fi
 
 # GC tuning options
@@ -192,4 +192,4 @@ JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"
 JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT" 
 JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=false" 
 JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false" 
-JVM_OPTS="$JVM_OPTS -Xss194k"
+JVM_OPTS="$JVM_OPTS -Xss228k"

--- a/test/conf/cassandra-env.sh
+++ b/test/conf/cassandra-env.sh
@@ -150,7 +150,7 @@ if [ "`uname`" = "Linux" ] ; then
     # thread-per-client.  (Best practice is for client connections to
     # be pooled anyway.) Only do so on Linux where it is known to be
     # supported.
-    JVM_OPTS="$JVM_OPTS -Xss228k"
+    JVM_OPTS="$JVM_OPTS -Xss256k"
 fi
 
 # GC tuning options
@@ -192,4 +192,4 @@ JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"
 JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT" 
 JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=false" 
 JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false" 
-JVM_OPTS="$JVM_OPTS -Xss228k"
+JVM_OPTS="$JVM_OPTS -Xss256k"


### PR DESCRIPTION
Now emits a stat event that reports the cass host to which each CQL request is sent.

Also, fixes the cass cluster start script for java 7, which has this problem:
https://issues.apache.org/jira/browse/CASSANDRA-5895
