### PR TITLE
Use once instead off on

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -343,7 +343,7 @@ Connection.prototype.connect = function(callback) {
               {'connectionInfo': self.connectionInfo});
   });
 
-  this.con.on('connect', function() {
+  this.con.once('connect', function() {
     clearTimeout(timeoutId);
 
     function decorateErrWithErrno(err, errno) {


### PR DESCRIPTION
We've been seeing issues in the account dump job.

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at addListener (events.js:160:15)
    at ConnectionInPool.connect (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/node_modules/cassandra-client/lib/driver.js:683:8)
    at ensureConnection (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/node_modules/cassandra-client/lib/driver.js:1032:14)
    at EleConPool.PooledConnection._getNextCon (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/node_modules/cassandra-client/lib/driver.js:1058:5)
    at executeQuery (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/node_modules/cassandra-client/lib/driver.js:932:12)
    at Object.async.whilst (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/node_modules/async/lib/async.js:678:13)
    at EleConPool.PooledConnection.execute (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/node_modules/cassandra-client/lib/driver.js:928:9)
    at EleConPool.execute (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/lib/db/utils.js:28:43)
    at ColumnIterator.getOneColumn (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/lib/orm/orm/iterator.js:502:17)
    at BaseObjectIterator.getOneObject (/opt/ele-bundle-51615a1b15398bd288399d82d572346261a5c279/lib/orm/orm/iterator.js:796:6)
```
